### PR TITLE
Fix decoding of "UTF-8" registers

### DIFF
--- a/SungrowClient/SungrowClient.py
+++ b/SungrowClient/SungrowClient.py
@@ -259,11 +259,12 @@ class SungrowClient():
                             register_value = (register_value + u32_value * 0x10000 - 0xffffffff -1)
                         else:
                             register_value = register_value + u32_value * 0x10000
-                    elif register.get('datatype') == "UTF-8": # This seems to be Serial only, 10 bytes
+                    elif register.get('datatype') == "UTF-8":
                         utf_value = register_value.to_bytes(2, 'big')
-                        for x in range(1,5):
+                        for x in range(1, register.get('length', 5)): # the 5 is for downward compatibility with the previous version
                             utf_value += rr.registers[num+x].to_bytes(2, 'big')
-                        register_value = utf_value.decode()
+                        # remove trailing null bytes and convert to string
+                        register_value = utf_value.rstrip(b'\x00').decode('utf-8')
 
 
                     # We convert a system response to a human value 


### PR DESCRIPTION
This patch fixes the decoding of UTF-8 values ("serial_number", "dsp_software_version", "arm_software_version") 

Since the expected length of the value is not known at decoding time, the maximum length of the string needs to be provided in the "register-sungrow.yaml" as a "length" key with the "UTF-8" datatype:
```
     - name: "serial_number"
       level: 3
       address: 4990
       datatype: "UTF-8"
       length: 10
```
Downward compatibility is ensured by using a default length of 5.